### PR TITLE
Use Hugo Modules instead of git submodule for theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/hugo-bearblog"]
-	path = themes/hugo-bearblog
-	url = https://github.com/janraasch/hugo-bearblog.git

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/mustafatariq/mustafa-tariqk.github.io
+
+go 1.26.2
+
+require github.com/janraasch/hugo-bearblog v0.0.0-20260409171543-9cc8e29b9e79 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/janraasch/hugo-bearblog v0.0.0-20260409171543-9cc8e29b9e79 h1:s5MUWFUJ69wUXwAu2g6TwE+HOqPAOWVCsbZvMo/Sb9w=
+github.com/janraasch/hugo-bearblog v0.0.0-20260409171543-9cc8e29b9e79/go.mod h1:qVJ3S3qhkRf6smf5f8vveeV/QX3ui8poHckF6Ykt9AU=

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,5 @@
 baseURL = 'https://mustafatariqk.com'
-theme = "hugo-bearblog"
+theme = ["github.com/janraasch/hugo-bearblog"]
 
 title = "Mustafa's Notes"
 author = "Mustafa Tariq"


### PR DESCRIPTION
## Summary
- Replace git submodule with Hugo Modules for theme management
- Theme now pulled from Go module cache at build time instead of being stored in the repo
- Remove `.gitmodules` and `themes/hugo-bearblog` submodule
- Add `go.mod`/`go.sum` for Hugo module dependencies